### PR TITLE
Add vite.svg to stop 404 error

### DIFF
--- a/frontend/public/vite.svg
+++ b/frontend/public/vite.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <polygon points="50,15 61,39 88,39 66,59 75,86 50,70 25,86 34,59 12,39 39,39" fill="#646cff"/>
+</svg>


### PR DESCRIPTION
## Summary
- add `vite.svg` favicon to frontend

## Testing
- `pytest -q` *(fails: command not found)*
- `black --check backend && isort --check-only backend && flake8 backend` *(fails: many files would be reformatted)*
- `mypy backend` *(fails: many missing stubs)*
- `bash start.sh & sleep 5 && curl -s http://localhost:${PORT:-8000}/health` *(fails: missing environment variables)*
- `npm run dev` *(fails: vite not found)*