### PR TITLE
Fix start script env var checks

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -29,6 +29,8 @@ fi
 missing_vars=()
 [ -z "${OPENAI_API_KEY}" ] && missing_vars+=(OPENAI_API_KEY)
 [ -z "${DATABASE_URL}" ] && missing_vars+=(DATABASE_URL)
+[ -z "${LEARNX_ENV}" ] && missing_vars+=(LEARNX_ENV)
+[ -z "${PORT}" ] && missing_vars+=(PORT)
 
 if [ ${#missing_vars[@]} -ne 0 ]; then
   warn "Missing required environment variables: ${missing_vars[*]}"


### PR DESCRIPTION
## Summary
- ensure start.sh checks `LEARNX_ENV` and `PORT`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find version that satisfies the requirement fastapi==0.104.1)*
- `pytest -q` *(fails: command not found)*
- `black --check backend && isort --check-only backend && flake8 backend` *(fails: 16 files would be reformatted)*
- `mypy backend` *(fails: missing imports)*
- `bash start.sh & sleep 5 && curl -s http://localhost:${PORT:-8000}/health` *(fails: ModuleNotFoundError for sqlalchemy)*