### PR TITLE
docs(env): add placeholders for LEARNX_ENV and PORT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,8 @@ JWT_SECRET=your_jwt_secret_here  # Used for authentication tokens
 ACCESS_TOKEN_EXPIRE_MINUTES=60  # Token expiration time in minutes
 
 # Application Settings
-LEARNX_ENV=dev  # dev or prod
-PORT=8000  # Default port for the backend server
+LEARNX_ENV=  # dev or prod
+PORT=  # Default port for the backend server
 FRONTEND_URL=http://localhost:3000  # Frontend URL for CORS
 
 # Document Processing

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ An AI-powered study companion that helps students learn more effectively by prov
 3. Configure environment variables:
    ```bash
    # Edit .env with your configuration (created from .env.example)
-   # At minimum, update OPENAI_API_KEY and JWT_SECRET
+   # At minimum, update OPENAI_API_KEY, JWT_SECRET, LEARNX_ENV, and PORT
    ```
 
 4. Start the application:


### PR DESCRIPTION
## Summary
- add blank `LEARNX_ENV` and `PORT` in `.env.example`
- mention these variables in README setup steps

## Testing
- `pytest -q` *(fails: command not found)*
- `black --check backend && isort --check-only backend && flake8 backend` *(fails: would reformat files)*
- `mypy backend` *(fails: missing stubs and packages)*
- `bash start.sh & sleep 5 && curl -s http://localhost:${PORT:-8000}/health` *(fails: missing env vars)*