### PR TITLE
docs(repo): instruct npm install for frontend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ These must be set in Codex **Environment variables / Secrets** *before* the task
 ```
 
 *Adding new top‑level dirs?* Update this map or the lint target will fail.
+*When internet access is available, run `npm ci` (or `npm install`) inside `frontend/` to install node deps.*
 
 ---
 


### PR DESCRIPTION
## Summary
- mention running `npm ci` or `npm install` in `frontend/` when possible

## Testing
- `pytest -q` *(fails: command not found)*
- `black --check backend` *(fails: would reformat files)*
- `isort --check-only backend` *(fails: imports not sorted)*
- `flake8 backend` *(fails: command not found)*
- `mypy backend` *(fails: missing dependencies/stubs)*
- `bash start.sh & sleep 5 && curl -s http://localhost:${PORT:-8000}/health` *(fails: start.sh missing)*