### PR TITLE
Fix health endpoint test path

### DIFF
--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -6,7 +6,7 @@ client = TestClient(app)
 
 
 def test_health_endpoint():
-    response = client.get("/health")
+    response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
 


### PR DESCRIPTION
## Summary
- test root health endpoint

## Testing
- `pip install -r requirements-dev.txt` *(fails: no network)*
- `pytest -q` *(fails: command not found)*
- `black --check backend` *(fails: would reformat many files)*
- `isort --check-only backend` *(fails: imports not sorted)*
- `flake8 backend` *(fails: command not found)*
- `mypy backend` *(fails: missing stubs)*
- `bash start.sh & sleep 5 && curl -s http://localhost:8000/` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*