### PR TITLE
docs(repo): add pip install step to setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ These must be set in Codex **Environment variables / Secrets** *before* the task
 
 *Adding new top‑level dirs?* Update this map or the lint target will fail.
 *When internet access is available, run `npm ci` (or `npm install`) inside `frontend/` to install node deps.*
+*Before running the build or test targets, run `pip install -r requirements.txt` to install runtime dependencies.*
 
 ---
 


### PR DESCRIPTION
## Summary
- remind contributors to run `pip install -r requirements.txt`

## Testing
- `pip install -r requirements.txt` *(fails: no route to host)*
- `npm ci` *(fails: Exit handler never called)*
- `pytest -q` *(fails: command not found)*
- `black --check backend && isort --check-only backend && flake8 backend` *(fails: files would be reformatted)*
- `mypy backend` *(fails: missing stubs and modules)*
- `bash start.sh & sleep 5 && curl -s http://localhost:${PORT:-8000}/` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*