### PR TITLE
Add setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ These must be set in Codex **Environment variables / Secrets** *before* the task
 *Adding new top‑level dirs?* Update this map or the lint target will fail.
 *When internet access is available, run `npm ci` (or `npm install`) inside `frontend/` to install node deps.*
 *Before running the build or test targets, run `pip install -r requirements.txt` to install runtime dependencies.*
+*Prefer `bash setup.sh` to install both Python and Node dependencies in one step.*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ An AI-powered study companion that helps students learn more effectively by prov
    cd LEARN-X
    ```
 
+2. Install dependencies (preferred):
+   ```bash
+   bash setup.sh
+   ```
+
 
 ## Project Structure
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+[ -z "$OPENAI_API_KEY" ] && { echo "OPENAI_API_KEY not set"; exit 1; }
+[ -z "$DATABASE_URL" ] && { echo "DATABASE_URL not set"; exit 1; }
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+(cd frontend && npm ci)


### PR DESCRIPTION
## Summary
- add a project `setup.sh`
- document setup script as the recommended method in AGENTS and README

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found)*
- `pip install -r requirements-dev.txt` *(fails: No matching distribution found)*
- `pytest -q` *(fails: command not found)*
- `black --check backend && isort --check-only backend && flake8 backend` *(fails: files would be reformatted)*
- `mypy backend` *(fails with missing imports)*
- `bash start.sh & sleep 5 && curl -s http://localhost:${PORT:-8000}/` *(fails: ModuleNotFoundError)*