### PR TITLE
Add auth pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,8 @@ import { Box, Button, Container, Flex, Heading, Text, Link as ChakraLink, VStack
 import { Routes, Route, Link, useLocation } from 'react-router-dom'
 import { useState } from 'react'
 
+import { LoginPage, RegisterPage } from './pages/Auth'
+
 // Import our components
 import { SplitScreenLayout } from './components/Layout'
 import { PDFViewer } from './components/DocumentViewer'
@@ -102,12 +104,29 @@ const Navigation = () => {
 
       <Box display={{ base: 'block', md: 'flex' }}>
         <ChakraLink as={Link} to="/study">
-          <Button 
-            variant={location.pathname === '/study' ? 'solid' : 'ghost'} 
-            mr={3} 
+          <Button
+            variant={location.pathname === '/study' ? 'solid' : 'ghost'}
+            mr={3}
             _hover={{ bg: 'teal.700' }}
           >
             Study
+          </Button>
+        </ChakraLink>
+        <ChakraLink as={Link} to="/login">
+          <Button
+            variant={location.pathname === '/login' ? 'solid' : 'ghost'}
+            mr={3}
+            _hover={{ bg: 'teal.700' }}
+          >
+            Login
+          </Button>
+        </ChakraLink>
+        <ChakraLink as={Link} to="/register">
+          <Button
+            variant={location.pathname === '/register' ? 'solid' : 'ghost'}
+            _hover={{ bg: 'teal.700' }}
+          >
+            Register
           </Button>
         </ChakraLink>
       </Box>
@@ -124,6 +143,8 @@ function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/study" element={<StudyPage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
         </Routes>
       </Box>
     </Box>

--- a/frontend/src/pages/Auth/LoginPage.tsx
+++ b/frontend/src/pages/Auth/LoginPage.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { Box, Button, Container, FormControl, FormLabel, Input, Heading, VStack, Alert, AlertIcon } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
+import { login } from '../../services/auth';
+
+const LoginPage = () => {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const data = await login(email, password);
+      localStorage.setItem('token', data.access_token);
+      navigate('/study');
+    } catch (err) {
+      setError('Invalid credentials');
+    }
+  };
+
+  return (
+    <Container maxW="sm" py={10}>
+      <Box p={6} borderWidth="1px" borderRadius="lg" boxShadow="md">
+        <Heading mb={4} size="md">Login</Heading>
+        {error && (
+          <Alert status="error" mb={4}>
+            <AlertIcon />
+            {error}
+          </Alert>
+        )}
+        <form onSubmit={handleSubmit}>
+          <VStack spacing={4}>
+            <FormControl isRequired>
+              <FormLabel>Email</FormLabel>
+              <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+            </FormControl>
+            <FormControl isRequired>
+              <FormLabel>Password</FormLabel>
+              <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+            </FormControl>
+            <Button type="submit" colorScheme="teal" width="full">Login</Button>
+          </VStack>
+        </form>
+      </Box>
+    </Container>
+  );
+};
+
+export default LoginPage;

--- a/frontend/src/pages/Auth/RegisterPage.tsx
+++ b/frontend/src/pages/Auth/RegisterPage.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { Box, Button, Container, FormControl, FormLabel, Input, Heading, VStack, Alert, AlertIcon } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
+import { register } from '../../services/auth';
+
+const RegisterPage = () => {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await register(email, password, firstName, lastName);
+      navigate('/login');
+    } catch (err) {
+      setError('Registration failed');
+    }
+  };
+
+  return (
+    <Container maxW="sm" py={10}>
+      <Box p={6} borderWidth="1px" borderRadius="lg" boxShadow="md">
+        <Heading mb={4} size="md">Register</Heading>
+        {error && (
+          <Alert status="error" mb={4}>
+            <AlertIcon />
+            {error}
+          </Alert>
+        )}
+        <form onSubmit={handleSubmit}>
+          <VStack spacing={4}>
+            <FormControl isRequired>
+              <FormLabel>Email</FormLabel>
+              <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+            </FormControl>
+            <FormControl isRequired>
+              <FormLabel>Password</FormLabel>
+              <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+            </FormControl>
+            <FormControl>
+              <FormLabel>First Name</FormLabel>
+              <Input value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+            </FormControl>
+            <FormControl>
+              <FormLabel>Last Name</FormLabel>
+              <Input value={lastName} onChange={(e) => setLastName(e.target.value)} />
+            </FormControl>
+            <Button type="submit" colorScheme="teal" width="full">Register</Button>
+          </VStack>
+        </form>
+      </Box>
+    </Container>
+  );
+};
+
+export default RegisterPage;

--- a/frontend/src/pages/Auth/index.ts
+++ b/frontend/src/pages/Auth/index.ts
@@ -1,0 +1,2 @@
+export { default as LoginPage } from './LoginPage';
+export { default as RegisterPage } from './RegisterPage';

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,29 @@
+import axios from 'axios';
+
+const API_URL = '/api/v1';
+
+export async function login(email: string, password: string) {
+  const data = new URLSearchParams();
+  data.append('username', email);
+  data.append('password', password);
+  const response = await axios.post(`${API_URL}/auth/token`, data, {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+  });
+  return response.data as { access_token: string; token_type: string };
+}
+
+export async function register(
+  email: string,
+  password: string,
+  firstName?: string,
+  lastName?: string
+) {
+  const params = {
+    email,
+    password,
+    first_name: firstName,
+    last_name: lastName
+  };
+  const response = await axios.post(`${API_URL}/auth/register`, null, { params });
+  return response.data as { message: string };
+}


### PR DESCRIPTION
## Summary
- add auth API helper
- add login and registration pages and routes

## Testing
- `pytest -q`
- `black --check backend`
- `isort --check-only backend`
- `flake8 backend`
- `mypy backend`
- `bash start.sh & sleep 5 && curl -s http://localhost:${PORT:-8000}/`