### PR TITLE
Add frontend stubs for dashboard & settings

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,8 @@ import { Routes, Route, Link, useLocation } from 'react-router-dom'
 import { useState } from 'react'
 
 import { LoginPage, RegisterPage } from './pages/Auth'
+import { DashboardPage } from './pages/Dashboard'
+import { SettingsPage } from './pages/Settings'
 
 // Import our components
 import { SplitScreenLayout } from './components/Layout'
@@ -103,6 +105,15 @@ const Navigation = () => {
       </Flex>
 
       <Box display={{ base: 'block', md: 'flex' }}>
+        <ChakraLink as={Link} to="/dashboard">
+          <Button
+            variant={location.pathname === '/dashboard' ? 'solid' : 'ghost'}
+            mr={3}
+            _hover={{ bg: 'teal.700' }}
+          >
+            Dashboard
+          </Button>
+        </ChakraLink>
         <ChakraLink as={Link} to="/study">
           <Button
             variant={location.pathname === '/study' ? 'solid' : 'ghost'}
@@ -129,6 +140,14 @@ const Navigation = () => {
             Register
           </Button>
         </ChakraLink>
+        <ChakraLink as={Link} to="/settings">
+          <Button
+            variant={location.pathname === '/settings' ? 'solid' : 'ghost'}
+            _hover={{ bg: 'teal.700' }}
+          >
+            Settings
+          </Button>
+        </ChakraLink>
       </Box>
     </Flex>
   )
@@ -142,9 +161,11 @@ function App() {
       <Box pt={2} px={2}>
         <Routes>
           <Route path="/" element={<Home />} />
+          <Route path="/dashboard" element={<DashboardPage />} />
           <Route path="/study" element={<StudyPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
+          <Route path="/settings" element={<SettingsPage />} />
         </Routes>
       </Box>
     </Box>

--- a/frontend/src/components/Dashboard/DocumentList.tsx
+++ b/frontend/src/components/Dashboard/DocumentList.tsx
@@ -1,0 +1,31 @@
+import { VStack, Button, Box } from '@chakra-ui/react';
+
+export interface DashboardDocument {
+  id: number;
+  title: string;
+}
+
+interface DocumentListProps {
+  documents: DashboardDocument[];
+}
+
+const DocumentList = ({ documents }: DocumentListProps) => {
+  return (
+    <VStack align="stretch" spacing={2} mt={4}>
+      {documents.map((doc) => (
+        <Button key={doc.id} variant="ghost" justifyContent="flex-start">
+          {/* TODO: link to open document viewer */}
+          {doc.title}
+        </Button>
+      ))}
+      {documents.length === 0 && (
+        <Box color="gray.500" textAlign="center">
+          {/* TODO: fetch documents from API */}
+          No documents yet
+        </Box>
+      )}
+    </VStack>
+  );
+};
+
+export default DocumentList;

--- a/frontend/src/components/Dashboard/DragDropUpload.tsx
+++ b/frontend/src/components/Dashboard/DragDropUpload.tsx
@@ -1,0 +1,47 @@
+import { useRef } from 'react';
+import { Box, Text } from '@chakra-ui/react';
+
+const DragDropUpload = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFiles = (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const file = files[0];
+    // TODO: upload document via API
+    console.log('Uploading file', file.name);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleFiles(e.target.files);
+  };
+
+  return (
+    <Box
+      border="2px dashed"
+      borderColor="gray.300"
+      p={6}
+      textAlign="center"
+      borderRadius="md"
+      onDrop={handleDrop}
+      onDragOver={(e) => e.preventDefault()}
+      cursor="pointer"
+      onClick={() => inputRef.current?.click()}
+    >
+      <input
+        type="file"
+        accept="application/pdf"
+        ref={inputRef}
+        style={{ display: 'none' }}
+        onChange={handleChange}
+      />
+      <Text color="gray.600">Drag & drop PDF here or click to select</Text>
+    </Box>
+  );
+};
+
+export default DragDropUpload;

--- a/frontend/src/components/DocumentViewer/PDFViewer.tsx
+++ b/frontend/src/components/DocumentViewer/PDFViewer.tsx
@@ -95,6 +95,14 @@ const PDFViewer = ({ fileUrl }: PDFViewerProps) => {
     setScale(prev => Math.max(prev - 0.2, 0.5)); // Min zoom: 0.5x
   };
 
+  const handleTextSelection = () => {
+    const text = window.getSelection()?.toString();
+    if (text) {
+      // TODO: send selected text to generate a question automatically
+      console.log('Selected text:', text);
+    }
+  };
+
   return (
     <Box className="pdf-viewer" w="100%" h="100%" bg="white" borderRadius="md" overflow="hidden">
       {loading && (
@@ -133,7 +141,14 @@ const PDFViewer = ({ fileUrl }: PDFViewerProps) => {
           </Flex>
         </Flex>
         
-        <Box flex="1" p={4} overflow="auto" display="flex" justifyContent="center">
+        <Box
+          flex="1"
+          p={4}
+          overflow="auto"
+          display="flex"
+          justifyContent="center"
+          onMouseUp={handleTextSelection}
+        >
           <canvas ref={canvasRef} />
         </Box>
       </Flex>

--- a/frontend/src/components/Settings/SettingsPanel.tsx
+++ b/frontend/src/components/Settings/SettingsPanel.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import {
+  Box,
+  FormControl,
+  FormLabel,
+  Select,
+  Button,
+  VStack
+} from '@chakra-ui/react';
+
+export interface Preferences {
+  learningStyle: string;
+  complexity: string;
+  tone: string;
+}
+
+interface SettingsPanelProps {
+  initial?: Preferences;
+}
+
+const SettingsPanel = ({ initial }: SettingsPanelProps) => {
+  const [prefs, setPrefs] = useState<Preferences>(
+    initial || { learningStyle: '', complexity: '', tone: '' }
+  );
+
+  const handleChange = (key: keyof Preferences) => (
+    e: React.ChangeEvent<HTMLSelectElement>
+  ) => {
+    setPrefs((p) => ({ ...p, [key]: e.target.value }));
+  };
+
+  const handleSave = () => {
+    // TODO: persist preferences via API
+    console.log('Saving preferences', prefs);
+  };
+
+  return (
+    <Box p={4} borderWidth="1px" borderRadius="lg">
+      <VStack spacing={4} align="stretch">
+        <FormControl>
+          <FormLabel>Learning Style</FormLabel>
+          <Select
+            placeholder="Select style"
+            value={prefs.learningStyle}
+            onChange={handleChange('learningStyle')}
+          >
+            <option value="visual">Visual</option>
+            <option value="text">Text</option>
+            <option value="example">Example-based</option>
+          </Select>
+        </FormControl>
+
+        <FormControl>
+          <FormLabel>Complexity</FormLabel>
+          <Select
+            placeholder="Select complexity"
+            value={prefs.complexity}
+            onChange={handleChange('complexity')}
+          >
+            <option value="beginner">Beginner</option>
+            <option value="intermediate">Intermediate</option>
+            <option value="advanced">Advanced</option>
+          </Select>
+        </FormControl>
+
+        <FormControl>
+          <FormLabel>Tone</FormLabel>
+          <Select
+            placeholder="Select tone"
+            value={prefs.tone}
+            onChange={handleChange('tone')}
+          >
+            <option value="casual">Casual</option>
+            <option value="neutral">Neutral</option>
+            <option value="formal">Formal</option>
+          </Select>
+        </FormControl>
+
+        <Button colorScheme="teal" onClick={handleSave} width="full">
+          Save Preferences
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default SettingsPanel;

--- a/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import { Container, Heading } from '@chakra-ui/react';
+import DragDropUpload from '../../components/Dashboard/DragDropUpload';
+import DocumentList, { DashboardDocument } from '../../components/Dashboard/DocumentList';
+import { fetchDocuments } from '../../services/documents';
+
+const DashboardPage = () => {
+  const [documents, setDocuments] = useState<DashboardDocument[]>([]);
+
+  useEffect(() => {
+    // TODO: handle loading state and errors
+    fetchDocuments().then(setDocuments).catch(() => {});
+  }, []);
+
+  return (
+    <Container maxW="container.lg" py={8}>
+      <Heading size="lg" mb={4}>Your Documents</Heading>
+      <DragDropUpload />
+      <DocumentList documents={documents} />
+    </Container>
+  );
+};
+
+export default DashboardPage;

--- a/frontend/src/pages/Dashboard/index.ts
+++ b/frontend/src/pages/Dashboard/index.ts
@@ -1,0 +1,1 @@
+export { default as DashboardPage } from './DashboardPage';

--- a/frontend/src/pages/Settings/SettingsPage.tsx
+++ b/frontend/src/pages/Settings/SettingsPage.tsx
@@ -1,0 +1,13 @@
+import { Container, Heading } from '@chakra-ui/react';
+import SettingsPanel from '../../components/Settings/SettingsPanel';
+
+const SettingsPage = () => {
+  return (
+    <Container maxW="container.sm" py={8}>
+      <Heading size="lg" mb={4}>Preferences</Heading>
+      <SettingsPanel />
+    </Container>
+  );
+};
+
+export default SettingsPage;

--- a/frontend/src/pages/Settings/index.ts
+++ b/frontend/src/pages/Settings/index.ts
@@ -1,0 +1,1 @@
+export { default as SettingsPage } from './SettingsPage';

--- a/frontend/src/services/documents.ts
+++ b/frontend/src/services/documents.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import { DashboardDocument } from '../components/Dashboard/DocumentList';
+
+const API_URL = '/api/v1';
+
+export async function fetchDocuments(): Promise<DashboardDocument[]> {
+  // TODO: fetch documents from backend
+  const { data } = await axios.get(`${API_URL}/documents`);
+  return data as DashboardDocument[];
+}
+
+export async function uploadDocument(file: File) {
+  // TODO: upload document to backend
+  const formData = new FormData();
+  formData.append('file', file);
+  await axios.post(`${API_URL}/documents`, formData);
+}

--- a/frontend/src/services/preferences.ts
+++ b/frontend/src/services/preferences.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+import { Preferences } from '../components/Settings/SettingsPanel';
+
+const API_URL = '/api/v1';
+
+export async function updatePreferences(prefs: Preferences) {
+  // TODO: implement API call to persist user preferences
+  await axios.put(`${API_URL}/users/preferences`, prefs);
+}


### PR DESCRIPTION
## Summary
- add dashboard document list and drag-drop upload components
- add settings panel and service stubs
- stub text selection handling in PDF viewer
- wire new pages and routes in the app

## Testing
- `bash setup.sh` *(fails: Could not find a version that satisfies the requirement fastapi==0.104.1)*
- `pytest -q` *(fails: command not found)*
- `black --check backend && isort --check-only backend && flake8 backend` *(fails: would reformat files)*
- `mypy backend` *(fails: missing imports)*
- `bash start.sh & sleep 5 && curl -s http://localhost:${PORT:-8000}/` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*