### PR TITLE
feat(frontend): link dashboard to viewer and save preferences

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,48 +5,9 @@ import { useState } from 'react'
 import { LoginPage, RegisterPage } from './pages/Auth'
 import { DashboardPage } from './pages/Dashboard'
 import { SettingsPage } from './pages/Settings'
+import { StudyPage } from './pages/Study'
 
 // Import our components
-import { SplitScreenLayout } from './components/Layout'
-import { PDFViewer } from './components/DocumentViewer'
-import { ChatInterface } from './components/Chat'
-
-const StudyPage = () => {
-  const [documentUrl, setDocumentUrl] = useState('');
-  const [hasDocument, setHasDocument] = useState(false);
-  
-  // For demo purposes, load a sample PDF
-  const handleLoadSample = () => {
-    setDocumentUrl('https://arxiv.org/pdf/2307.09288.pdf');
-    setHasDocument(true);
-  };
-  
-  // If no document is loaded yet, show the document prompt
-  if (!hasDocument) {
-    return (
-      <Container centerContent maxW="container.md" py={10}>
-        <VStack spacing={8}>
-          <Heading as="h1" size="xl">Start Studying</Heading>
-          <Text>Load a sample document to begin</Text>
-          <Button colorScheme="teal" onClick={handleLoadSample} size="lg">
-            Load Sample Document
-          </Button>
-        </VStack>
-      </Container>
-    );
-  }
-  
-  // Split screen layout with document viewer and chat interface
-  return (
-    <Box h="calc(100vh - 60px)">
-      <SplitScreenLayout
-        leftContent={<PDFViewer fileUrl={documentUrl} />}
-        rightContent={<ChatInterface />}
-        initialLeftSize={60}
-      />
-    </Box>
-  );
-};
 
 // Home component
 const Home = () => {
@@ -163,6 +124,7 @@ function App() {
           <Route path="/" element={<Home />} />
           <Route path="/dashboard" element={<DashboardPage />} />
           <Route path="/study" element={<StudyPage />} />
+          <Route path="/study/:docId" element={<StudyPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
           <Route path="/settings" element={<SettingsPage />} />

--- a/frontend/src/components/Dashboard/DocumentList.tsx
+++ b/frontend/src/components/Dashboard/DocumentList.tsx
@@ -1,4 +1,5 @@
 import { VStack, Button, Box } from '@chakra-ui/react';
+import { Link as RouterLink } from 'react-router-dom';
 
 export interface DashboardDocument {
   id: number;
@@ -13,16 +14,18 @@ const DocumentList = ({ documents }: DocumentListProps) => {
   return (
     <VStack align="stretch" spacing={2} mt={4}>
       {documents.map((doc) => (
-        <Button key={doc.id} variant="ghost" justifyContent="flex-start">
-          {/* TODO: link to open document viewer */}
+        <Button
+          key={doc.id}
+          as={RouterLink}
+          to={`/study/${doc.id}`}
+          variant="ghost"
+          justifyContent="flex-start"
+        >
           {doc.title}
         </Button>
       ))}
       {documents.length === 0 && (
-        <Box color="gray.500" textAlign="center">
-          {/* TODO: fetch documents from API */}
-          No documents yet
-        </Box>
+        <Box color="gray.500" textAlign="center">No documents yet</Box>
       )}
     </VStack>
   );

--- a/frontend/src/components/Dashboard/DragDropUpload.tsx
+++ b/frontend/src/components/Dashboard/DragDropUpload.tsx
@@ -1,14 +1,24 @@
 import { useRef } from 'react';
 import { Box, Text } from '@chakra-ui/react';
+import { uploadDocument } from '../../services/documents';
 
-const DragDropUpload = () => {
+interface DragDropUploadProps {
+  onUpload?: () => void;
+}
+const DragDropUpload = ({ onUpload }: DragDropUploadProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleFiles = (files: FileList | null) => {
     if (!files || files.length === 0) return;
     const file = files[0];
-    // TODO: upload document via API
-    console.log('Uploading file', file.name);
+    uploadDocument(file)
+      .then(() => {
+        console.log('Uploaded file', file.name);
+        onUpload?.();
+      })
+      .catch(() => {
+        console.error('Failed to upload', file.name);
+      });
   };
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {

--- a/frontend/src/components/Settings/SettingsPanel.tsx
+++ b/frontend/src/components/Settings/SettingsPanel.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   VStack
 } from '@chakra-ui/react';
+import { updatePreferences } from '../../services/preferences';
 
 export interface Preferences {
   learningStyle: string;
@@ -30,8 +31,9 @@ const SettingsPanel = ({ initial }: SettingsPanelProps) => {
   };
 
   const handleSave = () => {
-    // TODO: persist preferences via API
-    console.log('Saving preferences', prefs);
+    updatePreferences(prefs).catch(() => {
+      console.error('Failed to save preferences');
+    });
   };
 
   return (

--- a/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -7,15 +7,18 @@ import { fetchDocuments } from '../../services/documents';
 const DashboardPage = () => {
   const [documents, setDocuments] = useState<DashboardDocument[]>([]);
 
+  const loadDocuments = () =>
+    fetchDocuments().then(setDocuments).catch(() => {});
+
   useEffect(() => {
     // TODO: handle loading state and errors
-    fetchDocuments().then(setDocuments).catch(() => {});
+    loadDocuments();
   }, []);
 
   return (
     <Container maxW="container.lg" py={8}>
       <Heading size="lg" mb={4}>Your Documents</Heading>
-      <DragDropUpload />
+      <DragDropUpload onUpload={loadDocuments} />
       <DocumentList documents={documents} />
     </Container>
   );

--- a/frontend/src/pages/Study/StudyPage.tsx
+++ b/frontend/src/pages/Study/StudyPage.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { 
+import { useState, useEffect } from 'react';
+import {
   Box, 
   Button, 
   Container,
@@ -18,11 +18,20 @@ import {
 import { SplitScreenLayout } from '../../components/Layout';
 import { PDFViewer } from '../../components/DocumentViewer';
 import { ChatInterface } from '../../components/Chat';
+import { useParams } from 'react-router-dom';
 
 const StudyPage = () => {
   const [documentUrl, setDocumentUrl] = useState<string>('');
   const [hasDocument, setHasDocument] = useState<boolean>(false);
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const { docId } = useParams<{ docId?: string }>();
+
+  useEffect(() => {
+    if (docId) {
+      setDocumentUrl(`/api/v1/documents/${docId}/download`);
+      setHasDocument(true);
+    }
+  }, [docId]);
 
   // For demo purposes, we'll use a sample PDF URL when the user clicks "Load Sample"
   const handleLoadSample = () => {

--- a/frontend/src/services/documents.ts
+++ b/frontend/src/services/documents.ts
@@ -4,14 +4,20 @@ import { DashboardDocument } from '../components/Dashboard/DocumentList';
 const API_URL = '/api/v1';
 
 export async function fetchDocuments(): Promise<DashboardDocument[]> {
-  // TODO: fetch documents from backend
-  const { data } = await axios.get(`${API_URL}/documents`);
+  const { data } = await axios.get(`${API_URL}/documents`, {
+    headers: {
+      Authorization: `Bearer ${localStorage.getItem('token')}`
+    }
+  });
   return data as DashboardDocument[];
 }
 
 export async function uploadDocument(file: File) {
-  // TODO: upload document to backend
   const formData = new FormData();
   formData.append('file', file);
-  await axios.post(`${API_URL}/documents`, formData);
+  await axios.post(`${API_URL}/documents`, formData, {
+    headers: {
+      Authorization: `Bearer ${localStorage.getItem('token')}`
+    }
+  });
 }

--- a/frontend/src/services/preferences.ts
+++ b/frontend/src/services/preferences.ts
@@ -4,6 +4,9 @@ import { Preferences } from '../components/Settings/SettingsPanel';
 const API_URL = '/api/v1';
 
 export async function updatePreferences(prefs: Preferences) {
-  // TODO: implement API call to persist user preferences
-  await axios.put(`${API_URL}/users/preferences`, prefs);
+  await axios.put(`${API_URL}/users/preferences`, prefs, {
+    headers: {
+      Authorization: `Bearer ${localStorage.getItem('token')}`
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- link documents in dashboard to the Study page
- upload PDFs through API and refresh list on success
- persist user preferences via API
- support `/study/:docId` route and load document from backend
- include auth token when calling document and preference APIs

## Testing
- `bash setup.sh` *(fails: `OPENAI_API_KEY not set`)*
- `pytest -q` *(fails: command not found)*
- `black --check backend` *(fails: would reformat files)*
- `isort --check-only backend` *(fails: imports not sorted)*
- `flake8 backend` *(fails: command not found)*
- `mypy backend` *(fails: missing stubs)*
- `bash start.sh & sleep 5 && curl -s http://localhost:8000/` *(fails: ModuleNotFoundError: 'sqlalchemy')*