### PR TITLE
Implement preferences endpoint and highlight questions

### DIFF
--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -1,0 +1,28 @@
+from typing import Any, Dict
+
+from fastapi import APIRouter, Body, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ....database.session import get_db
+from ....models.user import User
+from .auth import get_current_active_user
+
+router = APIRouter()
+
+
+@router.get("/preferences")
+async def get_preferences(current_user: User = Depends(get_current_active_user)):
+    return current_user.preferences or {}
+
+
+@router.put("/preferences")
+async def update_preferences(
+    prefs: Dict[str, Any] = Body(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    current_user.preferences = {**(current_user.preferences or {}), **prefs}
+    db.add(current_user)
+    db.commit()
+    db.refresh(current_user)
+    return current_user.preferences or {}

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,19 +1,20 @@
-from sqlalchemy import Column, String, Boolean
+from sqlalchemy import JSON, Boolean, Column, String
 from sqlalchemy.orm import relationship
 
-from .base import BaseModel
 from ..database.session import Base
+from .base import BaseModel
 
 
 class User(Base, BaseModel):
     """User model for authentication and profile"""
-    
+
     email = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
     is_active = Column(Boolean, default=True)
     first_name = Column(String, nullable=True)
     last_name = Column(String, nullable=True)
-    
+    preferences = Column(JSON, nullable=True)
+
     # Relationships
     documents = relationship("Document", back_populates="owner")
     conversations = relationship("Conversation", back_populates="user")

--- a/backend/tests/test_user_preferences.py
+++ b/backend/tests/test_user_preferences.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+
+from backend.app.main import app
+
+client = TestClient(app)
+
+
+def test_preferences_requires_auth():
+    response = client.put("/api/v1/users/preferences", json={"learningStyle": "visual"})
+    assert response.status_code == 401

--- a/frontend/src/components/Chat/ChatInterface.tsx
+++ b/frontend/src/components/Chat/ChatInterface.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, forwardRef, useImperativeHandle } from 'react';
 import {
   Box,
   Input,
@@ -19,7 +19,11 @@ interface Message {
   timestamp: Date;
 }
 
-const ChatInterface = () => {
+export interface ChatInterfaceHandle {
+  askQuestion: (text: string) => void;
+}
+
+const ChatInterface = forwardRef<ChatInterfaceHandle>((_, ref) => {
   const [messages, setMessages] = useState<Message[]>([
     {
       id: '1',
@@ -33,31 +37,43 @@ const ChatInterface = () => {
   const bgColor = useColorModeValue('white', 'gray.800');
   const borderColor = useColorModeValue('gray.200', 'gray.700');
   
-  const handleSendMessage = () => {
-    if (!input.trim()) return;
-    
-    // Add user message
+  const addUserMessage = (text: string) => {
     const userMessage: Message = {
       id: Date.now().toString(),
-      content: input,
+      content: text,
       sender: 'user',
       timestamp: new Date()
     };
-    
     setMessages(prev => [...prev, userMessage]);
-    setInput('');
-    
-    // Simulate AI response (in a real app, this would call your backend)
+  };
+
+  const simulateAIResponse = () => {
     setTimeout(() => {
       const aiMessage: Message = {
         id: (Date.now() + 1).toString(),
-        content: `This is a simulated response. In the actual application, this would be a response from your AI about the document you're viewing.`,
+        content:
+          'This is a simulated response. In the actual application, this would be a response from your AI about the document you\'re viewing.',
         sender: 'ai',
         timestamp: new Date()
       };
       setMessages(prev => [...prev, aiMessage]);
     }, 1000);
   };
+
+  const handleSendMessage = () => {
+    if (!input.trim()) return;
+    addUserMessage(input);
+    setInput('');
+    simulateAIResponse();
+  };
+
+  useImperativeHandle(ref, () => ({
+    askQuestion(text: string) {
+      if (!text.trim()) return;
+      addUserMessage(text);
+      simulateAIResponse();
+    }
+  }));
   
   const handleKeyPress = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {

--- a/frontend/src/components/Chat/index.ts
+++ b/frontend/src/components/Chat/index.ts
@@ -1,1 +1,2 @@
 export { default as ChatInterface } from './ChatInterface';
+export type { ChatInterfaceHandle } from './ChatInterface';

--- a/frontend/src/components/DocumentViewer/PDFViewer.tsx
+++ b/frontend/src/components/DocumentViewer/PDFViewer.tsx
@@ -8,9 +8,10 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.j
 
 interface PDFViewerProps {
   fileUrl: string;
+  onTextSelect?: (text: string) => void;
 }
 
-const PDFViewer = ({ fileUrl }: PDFViewerProps) => {
+const PDFViewer = ({ fileUrl, onTextSelect }: PDFViewerProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [pdfDoc, setPdfDoc] = useState<pdfjsLib.PDFDocumentProxy | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
@@ -98,8 +99,7 @@ const PDFViewer = ({ fileUrl }: PDFViewerProps) => {
   const handleTextSelection = () => {
     const text = window.getSelection()?.toString();
     if (text) {
-      // TODO: send selected text to generate a question automatically
-      console.log('Selected text:', text);
+      onTextSelect?.(text);
     }
   };
 

--- a/frontend/src/pages/Study/StudyPage.tsx
+++ b/frontend/src/pages/Study/StudyPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
   Box, 
   Button, 
@@ -17,12 +17,13 @@ import {
 } from '@chakra-ui/react';
 import { SplitScreenLayout } from '../../components/Layout';
 import { PDFViewer } from '../../components/DocumentViewer';
-import { ChatInterface } from '../../components/Chat';
+import { ChatInterface, ChatInterfaceHandle } from '../../components/Chat';
 import { useParams } from 'react-router-dom';
 
 const StudyPage = () => {
   const [documentUrl, setDocumentUrl] = useState<string>('');
   const [hasDocument, setHasDocument] = useState<boolean>(false);
+  const chatRef = useRef<ChatInterfaceHandle>(null);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { docId } = useParams<{ docId?: string }>();
 
@@ -104,8 +105,8 @@ const StudyPage = () => {
   return (
     <Box h="100vh">
       <SplitScreenLayout
-        leftContent={<PDFViewer fileUrl={documentUrl} />}
-        rightContent={<ChatInterface />}
+        leftContent={<PDFViewer fileUrl={documentUrl} onTextSelect={(t) => chatRef.current?.askQuestion(t)} />}
+        rightContent={<ChatInterface ref={chatRef} />}
         initialLeftSize={60}
       />
     </Box>


### PR DESCRIPTION
## Summary
- add preferences column to User model
- implement `/api/v1/users/preferences` endpoints
- expose ChatInterface methods and connect PDFViewer highlight to chat
- add regression test for user preferences auth

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.104.1)*
- `pytest -q` *(fails: command not found)*
- `black --check backend` *(fails: 16 files would be reformatted)*
- `isort --check-only backend` *(fails: imports incorrectly sorted)*
- `mypy backend` *(fails: missing type stubs and packages)*
- `bash start.sh & sleep 5 && curl -s http://localhost:8000/` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*