### PR TITLE
Fix: Ensure backend waits for DB and clarify .env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ An AI-powered study companion that helps students learn more effectively by prov
    bash setup.sh
    ```
 
+## Environment Configuration
+
+Before running the application, you need to set up your environment variables.
+
+1.  **Copy the example environment file:**
+    ```bash
+    cp .env.example .env
+    ```
+2.  **Update `.env`:**
+    Open the newly created `.env` file and update the following variables:
+    *   `OPENAI_API_KEY`: Your OpenAI API key.
+    *   `JWT_SECRET`: A strong, unique secret for signing JWTs. You can generate one using a tool like `openssl rand -hex 32`.
+
+    Ensure other variables like `DATABASE_URL`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` are suitable for your environment if you're not using the default Docker setup. For the default Docker setup (`docker-compose up`), the pre-configured database values should work out of the box.
+
 ### Running with Docker
 
 1. Copy `.env.example` to `.env` and fill in the required values.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,9 @@ services:
       - FRONTEND_URL=${FRONTEND_URL}
       - PYTHONUNBUFFERED=1
       - PYTHONDONTWRITEBYTECODE=1
+    depends_on:
+      db:
+        condition: service_healthy
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
This commit addresses a potential issue where the backend service might fail to start correctly because the database service is not yet fully ready.

Changes:
- Modified `docker-compose.yml` to add a `depends_on` condition for the `backend` service, making it wait for the `db` service to be healthy before starting.
- Verified `start.sh` and `setup.sh` scripts; they are not directly involved in the Dockerized startup and do not handle `.env` creation.
- Added a new "Environment Configuration" section to `README.md` to instruct you on creating and populating the `.env` file from `.env.example`, which is crucial for Docker Compose to pick up necessary environment variables.