### PR TITLE
Add regenerate response endpoint

### DIFF
--- a/backend/app/api/v1/endpoints/conversations.py
+++ b/backend/app/api/v1/endpoints/conversations.py
@@ -1,21 +1,22 @@
-from fastapi import APIRouter, Depends, HTTPException, status, Body
-from sqlalchemy.orm import Session
-from typing import List, Optional, Dict, Any
+import json
 import os
 from datetime import datetime
-import json
+from typing import Any, Dict, List, Optional
+
 import openai
-from langchain.text_splitter import RecursiveCharacterTextSplitter
-from langchain.embeddings import OpenAIEmbeddings
-from langchain.vectorstores.pgvector import PGVector
+from fastapi import APIRouter, Body, Depends, HTTPException, status
 from langchain.chains import ConversationalRetrievalChain
-from langchain.memory import ConversationBufferMemory
+from langchain.embeddings import OpenAIEmbeddings
 from langchain.llms import OpenAI
+from langchain.memory import ConversationBufferMemory
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.vectorstores.pgvector import PGVector
+from sqlalchemy.orm import Session
 
 from ....database.session import get_db
-from ....models.user import User
-from ....models.document import Document, DocumentChunk
 from ....models.conversation import Conversation, Message
+from ....models.document import Document, DocumentChunk
+from ....models.user import User
 from .auth import get_current_active_user
 
 router = APIRouter()
@@ -29,93 +30,99 @@ TONE_STYLES = ["casual", "neutral", "formal"]
 
 
 # Helper functions
-def format_user_query(query: str, learning_style: str, complexity: str, tone: str) -> str:
+def format_user_query(
+    query: str, learning_style: str, complexity: str, tone: str
+) -> str:
     """Format the user query with learning preferences"""
     # Base prompt with learning style preferences
     style_map = {
         "visual": "Use visual descriptions and spatial analogies.",
         "textual": "Provide clear textual explanations with precise definitions.",
-        "example": "Use practical examples and walk through concrete instances."
+        "example": "Use practical examples and walk through concrete instances.",
     }
-    
+
     complexity_map = {
         "beginner": "Explain at a beginner level, assuming minimal prior knowledge.",
         "intermediate": "Explain at an intermediate level, balancing detail and simplicity.",
-        "advanced": "Provide advanced explanations with full technical detail."
+        "advanced": "Provide advanced explanations with full technical detail.",
     }
-    
+
     tone_map = {
         "casual": "Use a friendly, conversational tone.",
         "neutral": "Use a balanced, neutral tone.",
-        "formal": "Use a formal, academic tone."
+        "formal": "Use a formal, academic tone.",
     }
-    
+
     style_instruction = style_map.get(learning_style, style_map["textual"])
-    complexity_instruction = complexity_map.get(complexity, complexity_map["intermediate"])
+    complexity_instruction = complexity_map.get(
+        complexity, complexity_map["intermediate"]
+    )
     tone_instruction = tone_map.get(tone, tone_map["neutral"])
-    
+
     formatted_query = f"{query}\n\nAnswer based on the following preferences:\n- {style_instruction}\n- {complexity_instruction}\n- {tone_instruction}\n\nIf the answer is in the document, cite the specific page numbers, sections, or paragraphs where the information was found."
-    
+
     return formatted_query
 
 
 def setup_qa_system(document_id: int, db: Session):
     """Set up the QA system for a specific document"""
     # Get document chunks from database
-    chunks = db.query(DocumentChunk).filter(DocumentChunk.document_id == document_id).all()
-    
+    chunks = (
+        db.query(DocumentChunk).filter(DocumentChunk.document_id == document_id).all()
+    )
+
     if not chunks:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="No chunks found for this document"
+            detail="No chunks found for this document",
         )
-    
+
     # Initialize OpenAI embeddings
     embeddings = OpenAIEmbeddings(openai_api_key=OPENAI_API_KEY)
-    
+
     # Create a vector store with the document chunks
     connection_string = DATABASE_URL
     collection_name = f"document_{document_id}"
-    
+
     # Check if vector store already exists
     try:
         # Try to load existing vector store
         vector_store = PGVector(
             collection_name=collection_name,
             connection_string=connection_string,
-            embedding_function=embeddings
+            embedding_function=embeddings,
         )
     except Exception as e:
         # Create a new vector store if it doesn't exist
         texts = [chunk.content for chunk in chunks]
-        metadatas = [{
-            "page": chunk.page_number,
-            "chunk_index": chunk.chunk_index,
-            "document_id": document_id
-        } for chunk in chunks]
-        
+        metadatas = [
+            {
+                "page": chunk.page_number,
+                "chunk_index": chunk.chunk_index,
+                "document_id": document_id,
+            }
+            for chunk in chunks
+        ]
+
         vector_store = PGVector.from_texts(
             texts=texts,
             metadatas=metadatas,
             embedding=embeddings,
             collection_name=collection_name,
-            connection_string=connection_string
+            connection_string=connection_string,
         )
-    
+
     # Create conversation memory
-    memory = ConversationBufferMemory(
-        memory_key="chat_history",
-        return_messages=True
-    )
-    
+    memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
+
     # Create QA chain
     qa_chain = ConversationalRetrievalChain.from_llm(
         llm=OpenAI(temperature=0, openai_api_key=OPENAI_API_KEY),
         retriever=vector_store.as_retriever(search_kwargs={"k": 3}),
         memory=memory,
-        return_source_documents=True
+        return_source_documents=True,
     )
-    
+
     return qa_chain
 
 
@@ -126,87 +133,87 @@ async def create_conversation(
     title: Optional[str] = None,
     preferences: Optional[Dict[str, Any]] = Body(None),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_active_user)
+    current_user: User = Depends(get_current_active_user),
 ):
     """Create a new conversation"""
     # Verify that the document exists and belongs to the user
-    document = db.query(Document).filter(
-        Document.id == document_id,
-        Document.user_id == current_user.id
-    ).first()
-    
+    document = (
+        db.query(Document)
+        .filter(Document.id == document_id, Document.user_id == current_user.id)
+        .first()
+    )
+
     if not document:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Document not found"
+            status_code=status.HTTP_404_NOT_FOUND, detail="Document not found"
         )
-    
+
     # Create default preferences if none provided
     if not preferences:
         preferences = {
             "learning_style": "textual",
             "complexity": "intermediate",
             "tone": "neutral",
-            "follow_up_questions": True
+            "follow_up_questions": True,
         }
-    
+
     # Create conversation record
     conversation = Conversation(
         title=title or f"Conversation about {document.title}",
         user_id=current_user.id,
         document_id=document_id,
-        preferences=preferences
+        preferences=preferences,
     )
-    
+
     db.add(conversation)
     db.commit()
     db.refresh(conversation)
-    
+
     return {
         "id": conversation.id,
         "title": conversation.title,
         "created_at": conversation.created_at,
-        "document": {
-            "id": document.id,
-            "title": document.title
-        },
-        "preferences": conversation.preferences
+        "document": {"id": document.id, "title": document.title},
+        "preferences": conversation.preferences,
     }
 
 
 @router.get("/")
 async def get_conversations(
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_active_user)
+    db: Session = Depends(get_db), current_user: User = Depends(get_current_active_user)
 ):
     """Get all conversations for the current user"""
-    conversations = db.query(Conversation).filter(
-        Conversation.user_id == current_user.id
-    ).order_by(Conversation.created_at.desc()).all()
-    
+    conversations = (
+        db.query(Conversation)
+        .filter(Conversation.user_id == current_user.id)
+        .order_by(Conversation.created_at.desc())
+        .all()
+    )
+
     result = []
     for conv in conversations:
         document = None
         if conv.document_id:
             doc = db.query(Document).filter(Document.id == conv.document_id).first()
             if doc:
-                document = {
-                    "id": doc.id,
-                    "title": doc.title
-                }
-        
+                document = {"id": doc.id, "title": doc.title}
+
         # Count messages
-        message_count = db.query(Message).filter(Message.conversation_id == conv.id).count()
-        
-        result.append({
-            "id": conv.id,
-            "title": conv.title,
-            "created_at": conv.created_at,
-            "document": document,
-            "message_count": message_count,
-            "preferences": conv.preferences
-        })
-    
+        message_count = (
+            db.query(Message).filter(Message.conversation_id == conv.id).count()
+        )
+
+        result.append(
+            {
+                "id": conv.id,
+                "title": conv.title,
+                "created_at": conv.created_at,
+                "document": document,
+                "message_count": message_count,
+                "preferences": conv.preferences,
+            }
+        )
+
     return result
 
 
@@ -214,50 +221,55 @@ async def get_conversations(
 async def get_conversation(
     conversation_id: int,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_active_user)
+    current_user: User = Depends(get_current_active_user),
 ):
     """Get a specific conversation with all messages"""
-    conversation = db.query(Conversation).filter(
-        Conversation.id == conversation_id,
-        Conversation.user_id == current_user.id
-    ).first()
-    
+    conversation = (
+        db.query(Conversation)
+        .filter(
+            Conversation.id == conversation_id, Conversation.user_id == current_user.id
+        )
+        .first()
+    )
+
     if not conversation:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Conversation not found"
+            status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found"
         )
-    
+
     # Get document info if it exists
     document = None
     if conversation.document_id:
         doc = db.query(Document).filter(Document.id == conversation.document_id).first()
         if doc:
-            document = {
-                "id": doc.id,
-                "title": doc.title
-            }
-    
+            document = {"id": doc.id, "title": doc.title}
+
     # Get all messages for this conversation
-    messages = db.query(Message).filter(
-        Message.conversation_id == conversation_id
-    ).order_by(Message.created_at).all()
-    
-    message_list = [{
-        "id": msg.id,
-        "content": msg.content,
-        "role": msg.role,
-        "created_at": msg.created_at,
-        "citations": msg.citations
-    } for msg in messages]
-    
+    messages = (
+        db.query(Message)
+        .filter(Message.conversation_id == conversation_id)
+        .order_by(Message.created_at)
+        .all()
+    )
+
+    message_list = [
+        {
+            "id": msg.id,
+            "content": msg.content,
+            "role": msg.role,
+            "created_at": msg.created_at,
+            "citations": msg.citations,
+        }
+        for msg in messages
+    ]
+
     return {
         "id": conversation.id,
         "title": conversation.title,
         "created_at": conversation.created_at,
         "document": document,
         "messages": message_list,
-        "preferences": conversation.preferences
+        "preferences": conversation.preferences,
     }
 
 
@@ -266,48 +278,47 @@ async def create_message(
     conversation_id: int,
     content: str = Body(..., embed=True),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_active_user)
+    current_user: User = Depends(get_current_active_user),
 ):
     """Add a message to a conversation and get AI response"""
     # Verify conversation exists and belongs to user
-    conversation = db.query(Conversation).filter(
-        Conversation.id == conversation_id,
-        Conversation.user_id == current_user.id
-    ).first()
-    
+    conversation = (
+        db.query(Conversation)
+        .filter(
+            Conversation.id == conversation_id, Conversation.user_id == current_user.id
+        )
+        .first()
+    )
+
     if not conversation:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Conversation not found"
+            status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found"
         )
-    
+
     # Get document
     if not conversation.document_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="This conversation is not associated with a document"
+            detail="This conversation is not associated with a document",
         )
-    
+
     # Get preferences
     preferences = conversation.preferences or {}
     learning_style = preferences.get("learning_style", "textual")
     complexity = preferences.get("complexity", "intermediate")
     tone = preferences.get("tone", "neutral")
-    
+
     # Format user query with preferences
     formatted_query = format_user_query(content, learning_style, complexity, tone)
-    
+
     # Add user message to database
     user_message = Message(
-        content=content,
-        role="user",
-        conversation_id=conversation_id,
-        citations=None
+        content=content, role="user", conversation_id=conversation_id, citations=None
     )
     db.add(user_message)
     db.commit()
     db.refresh(user_message)
-    
+
     # Set up QA system
     try:
         qa_chain = setup_qa_system(conversation.document_id, db)
@@ -316,64 +327,174 @@ async def create_message(
         db.commit()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error setting up QA system: {str(e)}"
+            detail=f"Error setting up QA system: {str(e)}",
         )
-    
+
     # Get previous messages for context (excluding the one just added)
-    previous_messages = db.query(Message).filter(
-        Message.conversation_id == conversation_id,
-        Message.id != user_message.id
-    ).order_by(Message.created_at).all()
-    
+    previous_messages = (
+        db.query(Message)
+        .filter(
+            Message.conversation_id == conversation_id, Message.id != user_message.id
+        )
+        .order_by(Message.created_at)
+        .all()
+    )
+
     # Prepare chat history for QA chain
     chat_history = []
     for msg in previous_messages:
         if msg.role == "user":
             chat_history.append((msg.content, ""))
-    
+
     # Get AI response
     try:
         response = qa_chain({"question": formatted_query, "chat_history": chat_history})
         answer = response["answer"]
         source_docs = response.get("source_documents", [])
-        
+
         # Extract citations
         citations = []
         if source_docs:
             for i, doc in enumerate(source_docs):
                 metadata = doc.metadata if hasattr(doc, "metadata") else {}
                 page = metadata.get("page", "Unknown")
-                citations.append({
-                    "page": page,
-                    "text": doc.page_content[:100] + "..."
-                })
-        
+                citations.append({"page": page, "text": doc.page_content[:100] + "..."})
+
         # Add AI response to database
         ai_message = Message(
             content=answer,
             role="assistant",
             conversation_id=conversation_id,
-            citations=citations
+            citations=citations,
         )
         db.add(ai_message)
         db.commit()
         db.refresh(ai_message)
-        
+
         return {
             "id": ai_message.id,
             "content": ai_message.content,
             "role": ai_message.role,
             "created_at": ai_message.created_at,
-            "citations": ai_message.citations
+            "citations": ai_message.citations,
         }
-        
+
     except Exception as e:
         # If an error occurs, delete the user message to maintain conversation integrity
         db.delete(user_message)
         db.commit()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error getting AI response: {str(e)}"
+            detail=f"Error getting AI response: {str(e)}",
+        )
+
+
+@router.post("/{conversation_id}/regenerate")
+async def regenerate_last_message(
+    conversation_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    """Regenerate the assistant's response to the last user message"""
+    conversation = (
+        db.query(Conversation)
+        .filter(
+            Conversation.id == conversation_id, Conversation.user_id == current_user.id
+        )
+        .first()
+    )
+
+    if not conversation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found"
+        )
+
+    last_user_message = (
+        db.query(Message)
+        .filter(Message.conversation_id == conversation_id, Message.role == "user")
+        .order_by(Message.created_at.desc())
+        .first()
+    )
+
+    if not last_user_message:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No user message to regenerate",
+        )
+
+    preferences = conversation.preferences or {}
+    learning_style = preferences.get("learning_style", "textual")
+    complexity = preferences.get("complexity", "intermediate")
+    tone = preferences.get("tone", "neutral")
+
+    formatted_query = format_user_query(
+        last_user_message.content,
+        learning_style,
+        complexity,
+        tone,
+    )
+
+    try:
+        qa_chain = setup_qa_system(conversation.document_id, db)
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error setting up QA system: {str(e)}",
+        )
+
+    previous_messages = (
+        db.query(Message)
+        .filter(
+            Message.conversation_id == conversation_id,
+            Message.created_at < last_user_message.created_at,
+        )
+        .order_by(Message.created_at)
+        .all()
+    )
+
+    chat_history = []
+    for msg in previous_messages:
+        if msg.role == "user":
+            chat_history.append((msg.content, ""))
+
+    try:
+        response = qa_chain({"question": formatted_query, "chat_history": chat_history})
+        answer = response["answer"]
+        source_docs = response.get("source_documents", [])
+
+        citations = []
+        if source_docs:
+            for doc in source_docs:
+                metadata = doc.metadata if hasattr(doc, "metadata") else {}
+                page = metadata.get("page", "Unknown")
+                citations.append(
+                    {
+                        "page": page,
+                        "text": doc.page_content[:100] + "...",
+                    }
+                )
+
+        ai_message = Message(
+            content=answer,
+            role="assistant",
+            conversation_id=conversation_id,
+            citations=citations,
+        )
+        db.add(ai_message)
+        db.commit()
+        db.refresh(ai_message)
+
+        return {
+            "id": ai_message.id,
+            "content": ai_message.content,
+            "role": ai_message.role,
+            "created_at": ai_message.created_at,
+            "citations": ai_message.citations,
+        }
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error getting AI response: {str(e)}",
         )
 
 
@@ -382,77 +503,84 @@ async def update_preferences(
     conversation_id: int,
     preferences: Dict[str, Any] = Body(...),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_active_user)
+    current_user: User = Depends(get_current_active_user),
 ):
     """Update conversation preferences"""
-    conversation = db.query(Conversation).filter(
-        Conversation.id == conversation_id,
-        Conversation.user_id == current_user.id
-    ).first()
-    
+    conversation = (
+        db.query(Conversation)
+        .filter(
+            Conversation.id == conversation_id, Conversation.user_id == current_user.id
+        )
+        .first()
+    )
+
     if not conversation:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Conversation not found"
+            status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found"
         )
-    
+
     # Validate preferences
-    if "learning_style" in preferences and preferences["learning_style"] not in LEARNING_STYLES:
+    if (
+        "learning_style" in preferences
+        and preferences["learning_style"] not in LEARNING_STYLES
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid learning style. Must be one of: {LEARNING_STYLES}"
+            detail=f"Invalid learning style. Must be one of: {LEARNING_STYLES}",
         )
-    
-    if "complexity" in preferences and preferences["complexity"] not in COMPLEXITY_LEVELS:
+
+    if (
+        "complexity" in preferences
+        and preferences["complexity"] not in COMPLEXITY_LEVELS
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid complexity level. Must be one of: {COMPLEXITY_LEVELS}"
+            detail=f"Invalid complexity level. Must be one of: {COMPLEXITY_LEVELS}",
         )
-    
+
     if "tone" in preferences and preferences["tone"] not in TONE_STYLES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid tone style. Must be one of: {TONE_STYLES}"
+            detail=f"Invalid tone style. Must be one of: {TONE_STYLES}",
         )
-    
+
     # Update preferences
     current_prefs = conversation.preferences or {}
     current_prefs.update(preferences)
     conversation.preferences = current_prefs
-    
+
     db.add(conversation)
     db.commit()
     db.refresh(conversation)
-    
-    return {
-        "id": conversation.id,
-        "preferences": conversation.preferences
-    }
+
+    return {"id": conversation.id, "preferences": conversation.preferences}
 
 
 @router.delete("/{conversation_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_conversation(
     conversation_id: int,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_active_user)
+    current_user: User = Depends(get_current_active_user),
 ):
     """Delete a conversation"""
-    conversation = db.query(Conversation).filter(
-        Conversation.id == conversation_id,
-        Conversation.user_id == current_user.id
-    ).first()
-    
+    conversation = (
+        db.query(Conversation)
+        .filter(
+            Conversation.id == conversation_id, Conversation.user_id == current_user.id
+        )
+        .first()
+    )
+
     if not conversation:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Conversation not found"
+            status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found"
         )
-    
+
     # Delete all messages first
     db.query(Message).filter(Message.conversation_id == conversation_id).delete()
-    
+
     # Delete conversation
     db.delete(conversation)
     db.commit()
-    
+
     return None

--- a/learnx-pdf-chat-main/src/api/services.ts
+++ b/learnx-pdf-chat-main/src/api/services.ts
@@ -1,5 +1,4 @@
-
-import api from './axios';
+import api from "./axios";
 import {
   AuthLoginRequest,
   AuthRegisterRequest,
@@ -10,58 +9,65 @@ import {
   Conversation,
   Message,
   ConversationPreferences,
-  UserPreferences
-} from './types';
+  UserPreferences,
+} from "./types";
 
 // Auth services
-export const registerUser = async (data: AuthRegisterRequest): Promise<AuthRegisterResponse> => {
-  const response = await api.post('/auth/register', data);
+export const registerUser = async (
+  data: AuthRegisterRequest,
+): Promise<AuthRegisterResponse> => {
+  const response = await api.post("/auth/register", data);
   return response.data;
 };
 
-export const loginUser = async (data: AuthLoginRequest): Promise<AuthLoginResponse> => {
+export const loginUser = async (
+  data: AuthLoginRequest,
+): Promise<AuthLoginResponse> => {
   // Convert to form data as required by the API
   const formData = new FormData();
-  formData.append('username', data.username);
-  formData.append('password', data.password);
-  
-  const response = await api.post('/auth/token', formData, {
+  formData.append("username", data.username);
+  formData.append("password", data.password);
+
+  const response = await api.post("/auth/token", formData, {
     headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
-    }
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
   });
   return response.data;
 };
 
 export const getCurrentUser = async (): Promise<UserProfile> => {
-  const response = await api.get('/auth/me');
+  const response = await api.get("/auth/me");
   return response.data;
 };
 
 // Document services
 export const getDocuments = async (): Promise<Document[]> => {
-  const response = await api.get('/documents');
+  const response = await api.get("/documents");
   return response.data;
 };
 
-export const uploadDocument = async (file: File, title?: string): Promise<Document> => {
+export const uploadDocument = async (
+  file: File,
+  title?: string,
+): Promise<Document> => {
   const formData = new FormData();
-  formData.append('file', file);
+  formData.append("file", file);
   if (title) {
-    formData.append('title', title);
+    formData.append("title", title);
   }
 
-  const response = await api.post('/documents', formData, {
+  const response = await api.post("/documents", formData, {
     headers: {
-      'Content-Type': 'multipart/form-data'
-    }
+      "Content-Type": "multipart/form-data",
+    },
   });
   return response.data;
 };
 
 export const downloadDocument = async (id: string): Promise<Blob> => {
   const response = await api.get(`/documents/${id}/download`, {
-    responseType: 'blob'
+    responseType: "blob",
   });
   return response.data;
 };
@@ -73,37 +79,54 @@ export const deleteDocument = async (id: string): Promise<void> => {
 // Conversation services
 export const createConversation = async (
   document_id: string,
-  preferences?: ConversationPreferences
+  preferences?: ConversationPreferences,
 ): Promise<Conversation> => {
-  const response = await api.post('/conversations', { document_id, preferences });
+  const response = await api.post("/conversations", {
+    document_id,
+    preferences,
+  });
   return response.data;
 };
 
 export const sendMessage = async (
   conversationId: string,
-  content: string
+  content: string,
 ): Promise<Message> => {
-  const response = await api.post(`/conversations/${conversationId}/message`, { content });
+  const response = await api.post(`/conversations/${conversationId}/message`, {
+    content,
+  });
+  return response.data;
+};
+
+export const regenerateMessage = async (
+  conversationId: string,
+): Promise<Message> => {
+  const response = await api.post(
+    `/conversations/${conversationId}/regenerate`,
+  );
   return response.data;
 };
 
 export const updateConversationPreferences = async (
   conversationId: string,
-  preferences: ConversationPreferences
+  preferences: ConversationPreferences,
 ): Promise<ConversationPreferences> => {
-  const response = await api.put(`/conversations/${conversationId}/preferences`, preferences);
+  const response = await api.put(
+    `/conversations/${conversationId}/preferences`,
+    preferences,
+  );
   return response.data;
 };
 
 // User preferences services
 export const getUserPreferences = async (): Promise<UserPreferences> => {
-  const response = await api.get('/users/preferences');
+  const response = await api.get("/users/preferences");
   return response.data;
 };
 
 export const updateUserPreferences = async (
-  preferences: UserPreferences
+  preferences: UserPreferences,
 ): Promise<UserPreferences> => {
-  const response = await api.put('/users/preferences', preferences);
+  const response = await api.put("/users/preferences", preferences);
   return response.data;
 };

--- a/learnx-pdf-chat-main/src/components/Study/Chat/ChatWindow.tsx
+++ b/learnx-pdf-chat-main/src/components/Study/Chat/ChatWindow.tsx
@@ -1,28 +1,28 @@
-
-import { useState, useEffect, useRef } from 'react';
-import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
-import { useChatStore } from '@/state/chatStore';
-import MessageBubble from './MessageBubble';
-import SettingsModal from '../SettingsModal';
+import { useState, useEffect, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useChatStore } from "@/state/chatStore";
+import MessageBubble from "./MessageBubble";
+import SettingsModal from "../SettingsModal";
 
 interface ChatWindowProps {
   documentId: string;
 }
 
 const ChatWindow = ({ documentId }: ChatWindowProps) => {
-  const [userMessage, setUserMessage] = useState('');
+  const [userMessage, setUserMessage] = useState("");
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  
-  const { 
-    currentConversation, 
-    messages, 
-    isLoading, 
-    startConversation, 
-    sendUserMessage 
+
+  const {
+    currentConversation,
+    messages,
+    isLoading,
+    startConversation,
+    sendUserMessage,
+    regenerateLastResponse,
   } = useChatStore();
-  
+
   // Initialize conversation when component mounts
   useEffect(() => {
     const initConversation = async () => {
@@ -30,67 +30,67 @@ const ChatWindow = ({ documentId }: ChatWindowProps) => {
         await startConversation(documentId);
       }
     };
-    
+
     initConversation();
   }, [documentId, currentConversation, startConversation]);
-  
+
   // Scroll to bottom when messages change
   useEffect(() => {
     if (messagesEndRef.current) {
-      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+      messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
     }
   }, [messages]);
-  
+
   const handleSendMessage = async () => {
     if (!userMessage.trim()) return;
-    
+
     try {
       await sendUserMessage(userMessage);
-      setUserMessage('');
+      setUserMessage("");
     } catch (error) {
-      console.error('Error sending message:', error);
+      console.error("Error sending message:", error);
     }
   };
-  
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSendMessage();
     }
   };
-  
+
   return (
     <div className="chat-container">
       <div className="bg-white border-b p-3 flex items-center justify-between">
         <h3 className="font-medium">Chat with Document</h3>
-        <Button 
-          variant="ghost" 
+        <Button
+          variant="ghost"
           size="sm"
           onClick={() => setIsSettingsOpen(true)}
         >
-          <svg 
-            className="w-5 h-5" 
-            fill="none" 
-            stroke="currentColor" 
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
             viewBox="0 0 24 24"
           >
-            <path 
-              strokeLinecap="round" 
-              strokeLinejoin="round" 
-              strokeWidth={2} 
-              d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" 
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
             />
-            <path 
-              strokeLinecap="round" 
-              strokeLinejoin="round" 
-              strokeWidth={2} 
-              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" 
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
             />
           </svg>
           <span className="sr-only">Settings</span>
         </Button>
       </div>
-      
+
       <div className="chat-messages">
         {messages.length === 0 && !isLoading ? (
           <div className="text-center py-8 text-gray-500">
@@ -101,7 +101,7 @@ const ChatWindow = ({ documentId }: ChatWindowProps) => {
             <MessageBubble key={message.id} message={message} />
           ))
         )}
-        
+
         {isLoading && (
           <div className="assistant-message">
             <div className="flex space-x-2">
@@ -111,10 +111,10 @@ const ChatWindow = ({ documentId }: ChatWindowProps) => {
             </div>
           </div>
         )}
-        
+
         <div ref={messagesEndRef} />
       </div>
-      
+
       <div className="border-t p-3 bg-white">
         <div className="flex items-end space-x-2">
           <Textarea
@@ -125,32 +125,65 @@ const ChatWindow = ({ documentId }: ChatWindowProps) => {
             className="min-h-[60px] flex-1 resize-none"
             disabled={isLoading}
           />
-          <Button 
+          <Button
             onClick={handleSendMessage}
             disabled={!userMessage.trim() || isLoading}
             className="h-10 px-4"
           >
-            <svg 
-              className="w-5 h-5" 
-              fill="none" 
-              stroke="currentColor" 
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
               viewBox="0 0 24 24"
             >
-              <path 
-                strokeLinecap="round" 
-                strokeLinejoin="round" 
-                strokeWidth={2} 
-                d="M5 13l4 4L19 7" 
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 13l4 4L19 7"
               />
             </svg>
             <span className="sr-only">Send</span>
           </Button>
+          <Button
+            onClick={regenerateLastResponse}
+            disabled={isLoading || messages.length === 0}
+            variant="ghost"
+            className="h-10 px-4"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4.5 10.5a7.5 7.5 0 0113.5-3m1.5 6a7.5 7.5 0 01-13.5 3"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 8h3V5"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 16H6v3"
+              />
+            </svg>
+            <span className="sr-only">Regenerate</span>
+          </Button>
         </div>
       </div>
-      
-      <SettingsModal 
-        isOpen={isSettingsOpen} 
-        onClose={() => setIsSettingsOpen(false)} 
+
+      <SettingsModal
+        isOpen={isSettingsOpen}
+        onClose={() => setIsSettingsOpen(false)}
       />
     </div>
   );

--- a/learnx-pdf-chat-main/src/state/chatStore.ts
+++ b/learnx-pdf-chat-main/src/state/chatStore.ts
@@ -1,15 +1,11 @@
-
-import { create } from 'zustand';
-import { 
-  Conversation, 
-  Message, 
-  ConversationPreferences 
-} from '../api/types';
-import { 
-  createConversation, 
-  sendMessage, 
-  updateConversationPreferences 
-} from '../api/services';
+import { create } from "zustand";
+import { Conversation, Message, ConversationPreferences } from "../api/types";
+import {
+  createConversation,
+  sendMessage,
+  updateConversationPreferences,
+  regenerateMessage,
+} from "../api/services";
 
 interface ChatState {
   currentConversation: Conversation | null;
@@ -17,10 +13,14 @@ interface ChatState {
   isLoading: boolean;
   error: string | null;
   conversationPreferences: ConversationPreferences;
-  
-  startConversation: (documentId: string, preferences?: ConversationPreferences) => Promise<Conversation>;
+
+  startConversation: (
+    documentId: string,
+    preferences?: ConversationPreferences,
+  ) => Promise<Conversation>;
   sendUserMessage: (content: string) => Promise<void>;
   updatePreferences: (preferences: ConversationPreferences) => Promise<void>;
+  regenerateLastResponse: () => Promise<void>;
   setConversation: (conversation: Conversation) => void;
   setMessages: (messages: Message[]) => void;
   addMessage: (message: Message) => void;
@@ -32,8 +32,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
   isLoading: false,
   error: null,
   conversationPreferences: {},
-  
-  startConversation: async (documentId: string, preferences?: ConversationPreferences) => {
+
+  startConversation: async (
+    documentId: string,
+    preferences?: ConversationPreferences,
+  ) => {
     set({ isLoading: true, error: null });
     try {
       const conversation = await createConversation(documentId, preferences);
@@ -41,86 +44,110 @@ export const useChatStore = create<ChatState>((set, get) => ({
         currentConversation: conversation,
         messages: [],
         isLoading: false,
-        conversationPreferences: preferences || {}
+        conversationPreferences: preferences || {},
       });
       return conversation;
     } catch (error) {
-      console.error('Start conversation error:', error);
-      set({ 
-        isLoading: false, 
-        error: 'Failed to start conversation' 
+      console.error("Start conversation error:", error);
+      set({
+        isLoading: false,
+        error: "Failed to start conversation",
       });
       throw error;
     }
   },
-  
+
   sendUserMessage: async (content: string) => {
     const { currentConversation } = get();
     if (!currentConversation) {
-      set({ error: 'No active conversation' });
+      set({ error: "No active conversation" });
       return;
     }
-    
+
     // Add the user's message immediately
     const userMessage: Message = {
       id: `temp-${Date.now()}`,
       conversation_id: currentConversation.id,
       content,
-      role: 'user',
-      created_at: new Date().toISOString()
+      role: "user",
+      created_at: new Date().toISOString(),
     };
-    
-    set({ 
+
+    set({
       messages: [...get().messages, userMessage],
-      isLoading: true
+      isLoading: true,
     });
-    
+
     try {
       // Send the message to the API
       const response = await sendMessage(currentConversation.id, content);
-      
+
       // Add the assistant's response
       set({
         messages: [...get().messages, response],
-        isLoading: false
+        isLoading: false,
       });
     } catch (error) {
-      console.error('Send message error:', error);
-      set({ 
-        isLoading: false, 
-        error: 'Failed to send message' 
+      console.error("Send message error:", error);
+      set({
+        isLoading: false,
+        error: "Failed to send message",
       });
     }
   },
-  
+
+  regenerateLastResponse: async () => {
+    const { currentConversation, messages } = get();
+    if (!currentConversation) {
+      set({ error: "No active conversation" });
+      return;
+    }
+
+    const lastMessage = messages[messages.length - 1];
+    let updatedMessages = messages;
+    if (lastMessage && lastMessage.role === "assistant") {
+      updatedMessages = messages.slice(0, -1);
+    }
+
+    set({ messages: updatedMessages, isLoading: true });
+
+    try {
+      const response = await regenerateMessage(currentConversation.id);
+      set({ messages: [...updatedMessages, response], isLoading: false });
+    } catch (error) {
+      console.error("Regenerate message error:", error);
+      set({ isLoading: false, error: "Failed to regenerate message" });
+    }
+  },
+
   updatePreferences: async (preferences: ConversationPreferences) => {
     const { currentConversation } = get();
     if (!currentConversation) {
-      set({ error: 'No active conversation' });
+      set({ error: "No active conversation" });
       return;
     }
-    
+
     set({ isLoading: true, error: null });
     try {
       const updatedPrefs = await updateConversationPreferences(
-        currentConversation.id, 
-        preferences
+        currentConversation.id,
+        preferences,
       );
-      
+
       set({
         conversationPreferences: updatedPrefs,
-        isLoading: false
+        isLoading: false,
       });
     } catch (error) {
-      console.error('Update preferences error:', error);
-      set({ 
-        isLoading: false, 
-        error: 'Failed to update preferences' 
+      console.error("Update preferences error:", error);
+      set({
+        isLoading: false,
+        error: "Failed to update preferences",
       });
     }
   },
-  
+
   setConversation: (conversation) => set({ currentConversation: conversation }),
   setMessages: (messages) => set({ messages }),
-  addMessage: (message) => set({ messages: [...get().messages, message] })
+  addMessage: (message) => set({ messages: [...get().messages, message] }),
 }));


### PR DESCRIPTION
## Summary
- allow regenerating the last answer of a conversation
- expose regenerate API call on the frontend
- support regenerate in chat store
- add Regenerate button in chat window

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.104.1)*
- `pytest -q` *(fails: command not found)*
- `black --check backend && isort --check-only backend && flake8 backend` *(fails: would reformat many files)*
- `mypy backend` *(fails: missing type stubs and packages)*
- `bash start.sh & sleep 5 && curl -s http://localhost:${PORT:-8000}/` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
